### PR TITLE
Wip/update/strategy check reward earned

### DIFF
--- a/contracts/strategies/InitializableAbstractStrategy.sol
+++ b/contracts/strategies/InitializableAbstractStrategy.sol
@@ -15,6 +15,11 @@ interface IStrategyVault {
 abstract contract InitializableAbstractStrategy is Initializable, OwnableUpgradeable, ReentrancyGuardUpgradeable {
     using SafeERC20 for IERC20;
 
+    struct RewardData {
+        address token; // Reward token
+        uint256 amount; // Collectible amount
+    }
+
     address public vault;
     uint16 public withdrawSlippage;
     uint16 public depositSlippage;
@@ -137,7 +142,7 @@ abstract contract InitializableAbstractStrategy is Initializable, OwnableUpgrade
     function checkInterestEarned(address _asset) external view virtual returns (uint256);
 
     /// @notice Get the amount of claimable reward
-    function checkRewardEarned() external view virtual returns (uint256);
+    function checkRewardEarned() external view virtual returns (RewardData[] memory);
 
     /// @notice Get the total LP token balance for a asset.
     /// @param _asset Address of the asset.

--- a/contracts/strategies/aave/AaveStrategy.sol
+++ b/contracts/strategies/aave/AaveStrategy.sol
@@ -108,6 +108,11 @@ contract AaveStrategy is InitializableAbstractStrategy {
     }
 
     /// @inheritdoc InitializableAbstractStrategy
+    function checkRewardEarned() external pure override returns (RewardData[] memory) {
+        return (new RewardData[](0));
+    }
+
+    /// @inheritdoc InitializableAbstractStrategy
     function checkInterestEarned(address _asset) public view override returns (uint256) {
         uint256 balance = checkLPTokenBalance(_asset);
         uint256 allocatedAmt = allocatedAmount[_asset];
@@ -145,11 +150,6 @@ contract AaveStrategy is InitializableAbstractStrategy {
     /// @inheritdoc InitializableAbstractStrategy
     function supportsCollateral(address _asset) public view override returns (bool) {
         return assetToPToken[_asset] != address(0);
-    }
-
-    /// @inheritdoc InitializableAbstractStrategy
-    function checkRewardEarned() public pure override returns (uint256) {
-        return 0;
     }
 
     /// @notice Withdraw asset from Aave lending Pool

--- a/contracts/strategies/compound/CompoundStrategy.sol
+++ b/contracts/strategies/compound/CompoundStrategy.sol
@@ -118,8 +118,9 @@ contract CompoundStrategy is InitializableAbstractStrategy {
     }
 
     /// @inheritdoc InitializableAbstractStrategy
-    function checkRewardEarned() external view override returns (uint256 total) {
+    function checkRewardEarned() external view override returns (RewardData[] memory) {
         uint256 numAssets = assetsMapped.length;
+        RewardData[] memory rewardData = new RewardData[](numAssets);
         for (uint256 i; i < numAssets;) {
             address lpToken = assetToPToken[assetsMapped[i]];
             uint256 accrued = uint256(IComet(lpToken).baseTrackingAccrued(address(this)));
@@ -131,12 +132,12 @@ contract CompoundStrategy is InitializableAbstractStrategy {
             }
             accrued = ((accrued * config.multiplier) / FACTOR_SCALE);
 
-            // assuming homogeneous reward tokens
-            total += accrued - rewardPool.rewardsClaimed(lpToken, address(this));
+            rewardData[i] = RewardData(config.token, accrued - rewardPool.rewardsClaimed(lpToken, address(this)));
             unchecked {
                 ++i;
             }
         }
+        return rewardData;
     }
 
     /// @inheritdoc InitializableAbstractStrategy

--- a/contracts/strategies/stargate/StargateStrategy.sol
+++ b/contracts/strategies/stargate/StargateStrategy.sol
@@ -177,19 +177,7 @@ contract StargateStrategy is InitializableAbstractStrategy {
     }
 
     /// @inheritdoc InitializableAbstractStrategy
-    function supportsCollateral(address _asset) public view override returns (bool) {
-        return assetToPToken[_asset] != address(0);
-    }
-
-    /// @notice Get the amount STG pending to be collected.
-    /// @param _asset Address for the asset
-    function checkPendingRewards(address _asset) public view returns (uint256) {
-        if (!supportsCollateral(_asset)) revert CollateralNotSupported(_asset);
-        return ILPStaking(farm).pendingEmissionToken(assetInfo[_asset].rewardPID, address(this));
-    }
-
-    /// @inheritdoc InitializableAbstractStrategy
-    function checkRewardEarned() public view override returns (uint256) {
+    function checkRewardEarned() external view override returns (RewardData[] memory) {
         uint256 pendingRewards = 0;
         uint256 numAssets = assetsMapped.length;
         for (uint256 i; i < numAssets;) {
@@ -200,7 +188,21 @@ contract StargateStrategy is InitializableAbstractStrategy {
             }
         }
         uint256 claimedRewards = IERC20(rewardTokenAddress[0]).balanceOf(address(this));
-        return claimedRewards + pendingRewards;
+        RewardData[] memory rewardData = new RewardData[](1);
+        rewardData[0] = RewardData(rewardTokenAddress[0], claimedRewards + pendingRewards);
+        return rewardData;
+    }
+
+    /// @inheritdoc InitializableAbstractStrategy
+    function supportsCollateral(address _asset) public view override returns (bool) {
+        return assetToPToken[_asset] != address(0);
+    }
+
+    /// @notice Get the amount STG pending to be collected.
+    /// @param _asset Address for the asset
+    function checkPendingRewards(address _asset) public view returns (uint256) {
+        if (!supportsCollateral(_asset)) revert CollateralNotSupported(_asset);
+        return ILPStaking(farm).pendingEmissionToken(assetInfo[_asset].rewardPID, address(this));
     }
 
     /// @inheritdoc InitializableAbstractStrategy

--- a/test/strategy/AaveStrategy.t.sol
+++ b/test/strategy/AaveStrategy.t.sol
@@ -349,8 +349,8 @@ contract MiscellaneousTest is AaveStrategyTest {
     }
 
     function test_CheckRewardEarned() public {
-        uint256 reward = strategy.checkRewardEarned();
-        assertEq(reward, 0);
+        InitializableAbstractStrategy.RewardData[] memory rewardData = strategy.checkRewardEarned();
+        assertEq(rewardData.length, 0);
     }
 
     function test_CheckBalance() public {

--- a/test/strategy/CompoundStrategy.t.sol
+++ b/test/strategy/CompoundStrategy.t.sol
@@ -340,8 +340,8 @@ contract CheckRewardEarnedTest is CompoundStrategyTest {
         vm.warp(block.timestamp + 10 days);
         vm.mockCall(P_TOKEN, abi.encodeWithSignature("baseTrackingAccrued(address)"), abi.encode(10000000));
         IComet(P_TOKEN).accrueAccount(address(strategy));
-        uint256 reward = strategy.checkRewardEarned();
-        assertNotEq(reward, 0);
+        CompoundStrategy.RewardData[] memory rewardData = strategy.checkRewardEarned();
+        assert(rewardData.length > 0);
     }
 }
 
@@ -354,7 +354,7 @@ contract CheckAvailableBalanceTest is CompoundStrategyTest {
         _deposit();
     }
 
-    function test_checkAvilableBalance_LTAllocatedAmount() public {
+    function test_checkAvailableBalance_LTAllocatedAmount() public {
         vm.mockCall(ASSET, abi.encodeWithSignature("balanceOf(address)"), abi.encode(depositAmount - 100));
         uint256 availableBalance = strategy.checkAvailableBalance(ASSET);
         assertTrue(availableBalance < depositAmount);

--- a/test/strategy/StargateStrategy.t.sol
+++ b/test/strategy/StargateStrategy.t.sol
@@ -423,18 +423,19 @@ contract CollectReward is HarvestTest {
         _harvestIncentiveRate = uint16(bound(_harvestIncentiveRate, 0, 10000));
         vm.prank(USDS_OWNER);
         strategy.updateHarvestIncentiveRate(_harvestIncentiveRate);
-        uint256 initialRewards = strategy.checkRewardEarned();
+        StargateStrategy.RewardData[] memory initialRewards = strategy.checkRewardEarned();
 
-        assert(initialRewards == 0);
+        assert(initialRewards[0].token == strategy.rewardTokenAddress(0));
+        assert(initialRewards[0].amount == 0);
 
         // Do a time travel & mine dummy blocks for accumulating some rewards
         vm.warp(block.timestamp + 10 days);
         vm.roll(block.number + 1000);
 
-        uint256 currentRewards = strategy.checkRewardEarned();
-        assert(currentRewards > 0);
-        uint256 incentiveAmt = (currentRewards * strategy.harvestIncentiveRate()) / Helpers.MAX_PERCENTAGE;
-        uint256 harvestAmt = currentRewards - incentiveAmt;
+        StargateStrategy.RewardData[] memory currentRewards = strategy.checkRewardEarned();
+        assert(currentRewards[0].amount > 0);
+        uint256 incentiveAmt = (currentRewards[0].amount * strategy.harvestIncentiveRate()) / Helpers.MAX_PERCENTAGE;
+        uint256 harvestAmt = currentRewards[0].amount - incentiveAmt;
         address caller = actors[1];
 
         if (incentiveAmt > 0) {
@@ -450,7 +451,7 @@ contract CollectReward is HarvestTest {
         assertEq(ERC20(E_TOKEN).balanceOf(caller), incentiveAmt);
 
         currentRewards = strategy.checkRewardEarned();
-        assert(currentRewards == 0);
+        assert(currentRewards[0].amount == 0);
     }
 }
 


### PR DESCRIPTION
refactor(contracts/strategies): Update checkRewardEarned() response.
Issue: Each strategy has its own reward harvesting method, returning inconsistent response while querying the reward earned.

Fix: Add a consistent response struct for the function.

Changes:
* Update the strategy contracts.
* Update the related test files.