### PR TITLE
refactor(optimise): remove secondary `redeem()`

### DIFF
--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -20,8 +20,6 @@ interface IVault {
     function redeem(address _collateral, uint256 _usdsAmt, uint256 _minCollAmt, uint256 _deadline, address _strategy)
         external;
 
-    function redeem(address _collateral, uint256 _usdsAmt, uint256 _minCollAmt, uint256 _deadline) external;
-
     function rebase() external;
 
     function allocate(address _collateral, address _strategy, uint256 _amount) external;

--- a/contracts/vault/VaultCore.sol
+++ b/contracts/vault/VaultCore.sol
@@ -154,26 +154,6 @@ contract VaultCore is Initializable, OwnableUpgradeable, ReentrancyGuardUpgradea
     /// @param _usdsAmt Amount of USDs to be redeemed
     /// @param _minCollAmt minimum expected amount of collateral to be received
     /// @param _deadline expiry time of the transaction
-    /// @dev In case where there is not sufficient collateral available in the vault,
-    ///      the collateral is withdrawn from the default strategy configured for the collateral.
-    function redeem(address _collateral, uint256 _usdsAmt, uint256 _minCollAmt, uint256 _deadline)
-        external
-        nonReentrant
-    {
-        _redeem({
-            _collateral: _collateral,
-            _usdsAmt: _usdsAmt,
-            _minCollateralAmt: _minCollAmt,
-            _deadline: _deadline,
-            _strategyAddr: address(0)
-        });
-    }
-
-    /// @notice redeem USDs for `_collateral`
-    /// @param _collateral address of the collateral
-    /// @param _usdsAmt Amount of USDs to be redeemed
-    /// @param _minCollAmt minimum expected amount of collateral to be received
-    /// @param _deadline expiry time of the transaction
     /// @param _strategy address of the strategy to withdraw excess collateral from
     function redeem(address _collateral, uint256 _usdsAmt, uint256 _minCollAmt, uint256 _deadline, address _strategy)
         external

--- a/test/vault/VaultCore.t.sol
+++ b/test/vault/VaultCore.t.sol
@@ -724,7 +724,7 @@ contract TestRedeem is VaultCoreTest {
         emit log_named_uint("_minCollAmt", _minCollAmt);
         uint256 _expectedCollAmt = _minCollAmt + 10 * USDC_PRECISION;
         vm.expectRevert(abi.encodeWithSelector(Helpers.MinSlippageError.selector, _minCollAmt, _expectedCollAmt));
-        IVault(VAULT).redeem(_collateral, _usdsAmt, _expectedCollAmt, _deadline);
+        IVault(VAULT).redeem(_collateral, _usdsAmt, _expectedCollAmt, _deadline, address(0));
     }
 
     function test_RedeemFromVault() public {
@@ -741,7 +741,7 @@ contract TestRedeem is VaultCoreTest {
         vm.expectEmit(true, true, true, true, VAULT);
         emit Redeemed(redeemer, _collateral, _usdsBurnAmt, _calculatedCollateralAmt, _feeAmt);
         vm.prank(redeemer);
-        IVault(VAULT).redeem(_collateral, _usdsAmt, _calculatedCollateralAmt, _deadline);
+        IVault(VAULT).redeem(_collateral, _usdsAmt, _calculatedCollateralAmt, _deadline, address(0));
         uint256 balAfterFeeVault = ERC20(USDS).balanceOf(FEE_VAULT);
         uint256 balAfterUSDsRedeemer = ERC20(USDS).balanceOf(redeemer);
         uint256 balAfterUSDCeRedeemer = ERC20(USDCe).balanceOf(redeemer);
@@ -765,7 +765,7 @@ contract TestRedeem is VaultCoreTest {
         vm.expectEmit(true, true, true, true, VAULT);
         emit Redeemed(redeemer, _collateral, _usdsBurnAmt, _calculatedCollateralAmt, _feeAmt);
         vm.prank(redeemer);
-        IVault(VAULT).redeem(_collateral, _usdsAmt, _calculatedCollateralAmt, _deadline);
+        IVault(VAULT).redeem(_collateral, _usdsAmt, _calculatedCollateralAmt, _deadline, address(0));
         uint256 balAfterFeeVault = ERC20(USDS).balanceOf(FEE_VAULT);
         uint256 balAfterUSDsRedeemer = ERC20(USDS).balanceOf(redeemer);
         uint256 balAfterUSDCeRedeemer = ERC20(USDCe).balanceOf(redeemer);

--- a/test/vault/VaultIntegration.t.sol
+++ b/test/vault/VaultIntegration.t.sol
@@ -259,7 +259,7 @@ contract TestRedeem is VaultCoreTest {
         vm.expectEmit(true, true, true, true, VAULT);
         emit Redeemed(redeemer, _collateral, _usdsBurnAmt, _calculatedCollateralAmt, _feeAmt);
         vm.prank(redeemer);
-        IVault(VAULT).redeem(_collateral, _usdsAmt, _calculatedCollateralAmt, _deadline);
+        IVault(VAULT).redeem(_collateral, _usdsAmt, _calculatedCollateralAmt, _deadline, address(0));
         uint256 balAfterFeeVault = ERC20(USDS).balanceOf(FEE_VAULT);
         uint256 balAfterUSDsRedeemer = ERC20(USDS).balanceOf(redeemer);
         uint256 balAfterUSDCeRedeemer = ERC20(USDCe).balanceOf(redeemer);


### PR DESCRIPTION
- remove redeem(address _collateral, uint256 _usdsAmt, uint256 _minCollAmt, uint256 _deadline) , and at its place use redeem(address _collateral, uint256 _usdsAmt, uint256 _minCollAmt, uint256 _deadline, address _strategy) and if user wants to use the default strategy the UI can send address(0)
- breaking change for the UI